### PR TITLE
changes not a function error slightly

### DIFF
--- a/src/reportError.re
+++ b/src/reportError.re
@@ -46,9 +46,9 @@ let report parsedContent =>
       }
     )
   | Type_NotAFunction {actual} =>
-    "This is " ^
+    "This is a " ^
     actual ^
-    ". You seem to have called it as a function.\n" ^ "Careful with spaces, semicolons, parentheses, and whatever in-between!"
+    ". You seem to have called it as a function.\n" ^ "Be careful with spaces, semicolons, parentheses, and whatever in-between!"
   | Type_AppliedTooMany {functionType, expectedArgCount} =>
     sp
       "This function has type %s\nIt accepts only %d arguments. You gave more. Maybe you forgot a `;` somewhere?"


### PR DESCRIPTION
Hi! Just a small PR tweaking the `Type_NotAFunction` error message:

> This is string. You seem to have called it as a function.
> Careful with spaces, semicolons, parentheses, and whatever in-between!

To:

> This is string. You seem to have called it as a function.
> Be careful with spaces, semicolons, parentheses, and whatever in-between!